### PR TITLE
Potential fix for code scanning alert no. 13: Replacement of a substring with itself

### DIFF
--- a/data/js/calendar.js
+++ b/data/js/calendar.js
@@ -286,7 +286,7 @@ function fmtDateUTC(date){
 }
 
 function escapeText(text){
-  return (text || '').replace(/\\/g,'\\\\').replace(/;/g,'\;').replace(/,/g,'\,').replace(/\n/g,'\\n');
+  return (text || '').replace(/\\/g,'\\\\').replace(/;/g,'\\;').replace(/,/g,'\\,').replace(/\n/g,'\\n');
 }
 
 async function getAllDeadlines(){


### PR DESCRIPTION
Potential fix for [https://github.com/LowAhBeepOh/buddydocs/security/code-scanning/13](https://github.com/LowAhBeepOh/buddydocs/security/code-scanning/13)

To fix this, ensure replacement strings contain a literal backslash character before `;` and `,` in output. In JavaScript string literals, that requires escaping the backslash itself (`'\\;'` and `'\\,'`).

Best single fix without changing behavior elsewhere:
- Edit `escapeText` in `data/js/calendar.js` (around line 289).
- Replace:
  - `.replace(/;/g,'\;')` with `.replace(/;/g,'\\;')`
  - `.replace(/,/g,'\,')` with `.replace(/,/g,'\\,')`
- Keep all other logic unchanged.

No imports or new dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
