### PR TITLE
Potential fix for code scanning alert no. 7: DOM text reinterpreted as HTML

### DIFF
--- a/data/js/theme.js
+++ b/data/js/theme.js
@@ -195,6 +195,21 @@ export async function initAppFont() {
   root.style.setProperty('--bd-font-family', stack);
 }
 
+const ALLOWED_GOOGLE_FONTS = new Set([
+  'Inter Tight',
+  'Inter',
+  'Roboto',
+  'Poppins',
+  'DM Sans',
+  'Open Sans',
+  'Nunito',
+  'Lato',
+  'Figtree',
+  'Noto Sans',
+  'IBM Plex Sans',
+  'Cossette Titre',
+]);
+
 function gfFamilyParam(name){
   const map = {
     'Inter Tight': 'Inter+Tight',
@@ -234,6 +249,7 @@ export async function ensureWebFontLoaded(name){
     document.head.appendChild(style);
     return;
   }
+  if (!ALLOWED_GOOGLE_FONTS.has(name)) return;
   const link = document.createElement('link');
   link.id = id;
   link.rel = 'stylesheet';


### PR DESCRIPTION
Potential fix for [https://github.com/LowAhBeepOh/buddydocs/security/code-scanning/7](https://github.com/LowAhBeepOh/buddydocs/security/code-scanning/7)

Best fix: enforce a strict allowlist of supported remote webfont names in `data/js/theme.js` and only construct/append the Google Fonts `<link>` for those values. For anything else, return early. This preserves current functionality (known fonts still work) while preventing attacker-controlled strings from reaching URL construction and DOM insertion.

Concretely in `data/js/theme.js`:
- Add a constant set of allowed Google font names near `gfFamilyParam`/`gfLinkHref`.
- In `ensureWebFontLoaded(name)`, after handling `System UI`, `Custom`, and `OpenDyslexic`, check membership in that set; if not allowed, `return`.
- Keep existing mapping/URL generation unchanged for allowed values.

No import changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
